### PR TITLE
Update composer requirement of silverstripe/admin to ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "silverstripe/admin": "^1"
+        "silverstripe/admin": "^2"
     },
     "bin": [
         "from-source"


### PR DESCRIPTION
Updating requirements for `silverstripe/admin1` from `^1` to `^2` to work with CMS 5